### PR TITLE
Fix TypeScript config and import paths

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,21 +3,13 @@ import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox-mocha-ethers';
 
 const config: HardhatUserConfig = {
-  solidity: '0.8.18', // aligne avec le pragma de tes contrats
-  defaultNetwork: 'hardhat',
+  solidity: '0.8.18',
   networks: {
-    hardhat: {
-      type: 'edr-simulated', // réseau simulé Hardhat v3
-      chainType: 'l1',
-      mining: {
-        auto: true,
-        interval: 1000, // 1s : pas besoin de allowBlocksWithSameTimestamp
-      },
-    },
+    hardhat: {},
   },
   paths: {
-    sources: './src/blockchain/contracts',
-    artifacts: './src/blockchain/artifacts',
+    sources: './src/Blockchain/contracts',
+    artifacts: './src/Blockchain/artifacts',
   },
 };
 

--- a/src/Blockchain/blockchain.service.ts
+++ b/src/Blockchain/blockchain.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import { ethers } from 'hardhat'; // on utilise ethers fourni par Hardhat
+import hre from 'hardhat';
 
 @Injectable()
 export class BlockchainService implements OnModuleInit {
-  private diplomaContractAddress: string;
-  private diplomaContractAbi: any; // on peut typer plus finement via typechain, mais pour simplicité any
+  private diplomaContractAddress!: string;
+  private diplomaContractAbi!: any; // on peut typer plus finement via typechain, mais pour simplicité any
 
   async onModuleInit() {
     // Au démarrage du module (application), on déploie le contrat DiplomaRegistry
@@ -13,32 +13,27 @@ export class BlockchainService implements OnModuleInit {
 
   private async deployContract() {
     console.log('Deploying DiplomaRegistry smart contract...');
-    const [deployer] = await ethers.getSigners(); // le compte déployeur (compte[0] Hardhat)
-    const factory = await ethers.getContractFactory(
-      'DiplomaRegistry',
-      deployer,
-    );
+    const [deployer] = await hre.ethers.getSigners();
+    const factory = await hre.ethers.getContractFactory('DiplomaRegistry', deployer);
     const contract = await factory.deploy();
-    await contract.deployed();
-    this.diplomaContractAddress = contract.address;
-    // Récupérer l'ABI du contrat compilé
+    await contract.waitForDeployment();
+    this.diplomaContractAddress = await contract.getAddress();
     const artifact = await hre.artifacts.readArtifact('DiplomaRegistry');
     this.diplomaContractAbi = artifact.abi;
     console.log(`Contract deployed at address: ${this.diplomaContractAddress}`);
   }
 
   // Méthode utilitaire pour obtenir une instance du contrat connecté avec un signataire particulier
-  private getContractInstance(signer?: ethers.Signer) {
+  private getContractInstance(signer?: any) {
     if (!this.diplomaContractAddress) {
       throw new Error('Contract not deployed or address not set');
     }
     // Si aucun signer fourni, on utilise le provider par défaut (lecture seule)
-    const contract = new ethers.Contract(
+    return new hre.ethers.Contract(
       this.diplomaContractAddress,
       this.diplomaContractAbi,
-      signer || ethers.provider,
+      signer || hre.ethers.provider,
     );
-    return contract;
   }
 
   // Émettre un diplôme (stocke hash dans la blockchain) depuis une adresse donnée (owner)
@@ -46,15 +41,17 @@ export class BlockchainService implements OnModuleInit {
     walletPrivateKey: string,
     ipfsHash: string,
   ): Promise<number> {
-    const signer = new ethers.Wallet(walletPrivateKey, ethers.provider);
+    const signer = new hre.ethers.Wallet(walletPrivateKey, hre.ethers.provider);
     const contract = this.getContractInstance(signer);
     console.log(
       `Issuing diploma by ${signer.address} with hash ${ipfsHash}...`,
     );
     const tx = await contract.issueDiploma(ipfsHash);
-    const receipt = await tx.wait(); // attendre la confirmation (minage)
-    const event = receipt.events?.find((e) => e.event === 'DiplomaIssued');
-    const diplomaId = event?.args?.[0].toNumber(); // l'id du diplôme émis (args[0] du event)
+    const receipt = await tx.wait();
+    const event = receipt.logs?.find(
+      (e: any) => e.fragment?.name === 'DiplomaIssued',
+    );
+    const diplomaId = event?.args?.[0] ? Number(event.args[0]) : 0;
     return diplomaId;
   }
 
@@ -64,7 +61,7 @@ export class BlockchainService implements OnModuleInit {
     diplomaId: number,
     toAddress: string,
   ): Promise<void> {
-    const signer = new ethers.Wallet(fromPrivKey, ethers.provider);
+    const signer = new hre.ethers.Wallet(fromPrivKey, hre.ethers.provider);
     const contract = this.getContractInstance(signer);
     console.log(
       `Transferring diploma ${diplomaId} from ${signer.address} to ${toAddress} ...`,
@@ -78,7 +75,7 @@ export class BlockchainService implements OnModuleInit {
   async getDiplomaInfo(
     diplomaId: number,
   ): Promise<{ owner: string; ipfsHash: string; valid: boolean }> {
-    const contract = this.getContractInstance(); // pas de signer => requête read-only
+    const contract = this.getContractInstance();
     const [ipfsHash, owner, valid] = await contract.getDiploma(diplomaId);
     return { owner, ipfsHash, valid };
   }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller.ts';
-import { AppService } from './app.service.ts';
-import { BlockchainService } from './Blockchain/blockchain.service.ts';
-import { WalletService } from './wallets/wallet.service.ts';
-import { IpfsService } from './ipfs/ipfs.service.ts';
-import { DiplomaController } from './diploma/diploma.controller.ts';
-import { WalletController } from './wallets/wallet.controller.ts';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { BlockchainService } from './Blockchain/blockchain.service';
+import { WalletService } from './wallets/wallet.service';
+import { IpfsService } from './ipfs/ipfs.service';
+import { DiplomaController } from './diploma/diploma.controller';
+import { WalletController } from './wallets/wallet.controller';
 
 @Module({
   imports: [],

--- a/src/diploma/diploma.controller.ts
+++ b/src/diploma/diploma.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Get, Body, Param } from '@nestjs/common';
-import { IpfsService } from '../ipfs/ipfs.service.ts';
-import { WalletService } from '../wallets/wallet.service.ts';
-import { BlockchainService } from '../Blockchain/blockchain.service.jt';
+import { IpfsService } from '../ipfs/ipfs.service';
+import { WalletService } from '../wallets/wallet.service';
+import { BlockchainService } from '../Blockchain/blockchain.service';
 
 @Controller('diplomas')
 export class DiplomaController {

--- a/src/wallets/wallet.controller.ts
+++ b/src/wallets/wallet.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Post, Get } from '@nestjs/common';
-import { BlockchainService } from '../Blockchain/blockchain.service.ts';
-import { WalletService } from './wallet.service.ts';
-import { ethers } from 'ethers';
+import { BlockchainService } from '../Blockchain/blockchain.service';
+import { WalletService } from './wallet.service';
+import { JsonRpcProvider, parseEther } from 'ethers';
 
 @Controller('wallets')
 export class WalletController {
+  private provider = new JsonRpcProvider('http://127.0.0.1:8545');
+
   constructor(
     private readonly walletService: WalletService,
     private readonly blockchainService: BlockchainService,
@@ -15,16 +17,15 @@ export class WalletController {
   async createWallet() {
     const newWallet = this.walletService.createWallet();
     const address = newWallet.address;
-    // Optionnel: financer le wallet en ETH depuis le deployer pour qu'il puisse faire des tx
-    const [deployer] = await ethers.getSigners();
+    const deployer = await this.provider.getSigner();
     await deployer.sendTransaction({
       to: address,
-      value: ethers.utils.parseEther('10.0'),
+      value: parseEther('10.0'),
     });
     return {
       id: newWallet.id,
       address: newWallet.address,
-      privateKey: newWallet.privateKey, // on retourne la clé privée UNE FOIS (avertissement sécurité)
+      privateKey: newWallet.privateKey,
     };
   }
 

--- a/src/wallets/wallet.service.ts
+++ b/src/wallets/wallet.service.ts
@@ -15,7 +15,7 @@ export class WalletService {
   // Créer un nouveau wallet utilisateur
   createWallet(): UserWallet {
     // Générer un wallet Ethereum aléatoire
-    const wallet = ethers.Wallet.createRandom(); // génère une nouvelle clé aléatoire:contentReference[oaicite:26]{index=26}
+    const wallet = ethers.Wallet.createRandom(); // génère une nouvelle clé aléatoire
 
     const userWallet: UserWallet = {
       id: this.nextId++,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node16",
-    "outDir": "dist"
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
## Summary
- enable decorator metadata and experimental decorators
- clean up imports and update Hardhat config paths
- refactor blockchain and wallet services for ethers v6

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8257b66083268a547441c1a04b92